### PR TITLE
Add Docker Health Check for Runtime Image

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -3,9 +3,6 @@
     "build":{
         "dockerfile": "../docker/aspa-devel.dockerfile"
     },
-    "features": {
-      "ghcr.io/devcontainers/features/docker-in-docker:2": {}
-    },
     "customizations": {
       "vscode": {
         "extensions": [

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -3,6 +3,9 @@
     "build":{
         "dockerfile": "../docker/aspa-devel.dockerfile"
     },
+    "features": {
+      "ghcr.io/devcontainers/features/docker-in-docker:2": {}
+    },
     "customizations": {
       "vscode": {
         "extensions": [

--- a/app/api/health/route.ts
+++ b/app/api/health/route.ts
@@ -1,0 +1,5 @@
+import { NextResponse } from 'next/server';
+
+export function GET() {
+  return NextResponse.json({ status: 'ok' }, { status: 200 });
+}

--- a/app/api/health/route.ts
+++ b/app/api/health/route.ts
@@ -1,5 +1,5 @@
-import { NextResponse } from 'next/server';
+import { NextResponse } from "next/server";
 
 export function GET() {
-  return NextResponse.json({ status: 'ok' }, { status: 200 });
+  return NextResponse.json({ status: "ok" }, { status: 200 });
 }

--- a/docker/aspa-runtime.dockerfile
+++ b/docker/aspa-runtime.dockerfile
@@ -44,7 +44,7 @@ COPY --from=builder /app/tsconfig.json /app/tsconfig.json
 EXPOSE 3000
 
 # Add health check
-HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 \
+HEALTHCHECK --interval=30s --timeout=10s --start-period=90s --retries=3 \
   CMD curl -f http://localhost:3000/api/health || exit 1
 
 # Keep the container running indefinitely

--- a/docker/aspa-runtime.dockerfile
+++ b/docker/aspa-runtime.dockerfile
@@ -20,6 +20,9 @@ FROM ${BASE_REGISTRY}/${BASE_IMAGE} AS runtime
 
 USER root
 
+# Install curl for health check
+RUN apk add --no-cache curl
+
 # Install corepack
 RUN corepack enable
 RUN corepack prepare yarn@stable --activate
@@ -39,6 +42,10 @@ COPY --from=builder /app/tsconfig.json /app/tsconfig.json
 
 # Run the app
 EXPOSE 3000
+
+# Add health check
+HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 \
+  CMD curl -f http://localhost:3000/api/health || exit 1
 
 # Keep the container running indefinitely
 #CMD ["sleep", "infinity"] # USED FOR DEBUGGING


### PR DESCRIPTION
Changes made:

- Created /api/health endpoint at app/api/health/route.ts
- An expected response: 200 OK / { "status": "ok" } to indicate the app is up and responsive.
  --> curl -f fails if the response is not 2xx, and the exit 1 marks the container as unhealthy.
  --> if command fails 3 times in a row, Docker marks the container as unhealthy
- Installed curl in the runtime Docker image (Alpine-based) using apk add --no-cache curl.
- Added HEALTHCHECK instruction to the runtime Dockerfile.
- Verified that the health check passes, showing the app is healthy, and would fail when the endpoint is unavailable.