### PR TITLE
Chore/optimize docker images

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,39 @@
+# Development
+node_modules
+.git
+.storybook
+.husky
+.yarn/cache
+.devcontainer
+.github
+
+# Testing
+coverage
+*.test.*
+*.story.*
+jest.config.cjs
+jest.setup.cjs
+
+# Documentation
+README.md
+README
+CHANGELOG.md
+docs
+
+# Build outputs
+.next
+out
+dist
+build
+
+# IDE and Editor files
+.vscode
+.idea
+*.swp
+*.swo
+
+# Misc
+.DS_Store
+*.log
+.env*
+.eslintcache

--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -1,4 +1,4 @@
-import type { StorybookConfig } from '@storybook/nextjs';
+import type { StorybookConfig } from "@storybook/nextjs";
 
 const config: StorybookConfig = {
   core: {
@@ -6,10 +6,10 @@ const config: StorybookConfig = {
     disableTelemetry: true,
     enableCrashReports: false,
   },
-  stories: ['../components/**/*.(stories|story).@(js|jsx|ts|tsx)'],
-  addons: ['storybook-dark-mode'],
+  stories: ["../components/**/*.(stories|story).@(js|jsx|ts|tsx)"],
+  addons: ["storybook-dark-mode"],
   framework: {
-    name: '@storybook/nextjs',
+    name: "@storybook/nextjs",
     options: {},
   },
 };

--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -6,12 +6,16 @@ const config: StorybookConfig = {
     disableTelemetry: true,
     enableCrashReports: false,
   },
-  stories: ['../components/**/*.(stories|story).@(js|jsx|ts|tsx)'],
-  addons: ['storybook-dark-mode', '@storybook/addon-essentials', '@storybook/addon-interactions'],
+  stories: ["../components/**/*.(stories|story).@(js|jsx|ts|tsx)"],
+  addons: [
+    "storybook-dark-mode",
+    "@storybook/addon-essentials",
+    "@storybook/addon-interactions",
+  ],
   framework: {
     name: "@storybook/nextjs",
     options: {},
   },
-  staticDirs: [{from: '../public', to: ''}],
+  staticDirs: [{ from: "../public", to: "" }],
 };
 export default config;

--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -1,13 +1,13 @@
-import '@mantine/core/styles.css';
+import "@mantine/core/styles.css";
 
-import React, { useEffect } from 'react';
-import { addons } from '@storybook/preview-api';
-import { DARK_MODE_EVENT_NAME } from 'storybook-dark-mode';
-import { MantineProvider, useMantineColorScheme } from '@mantine/core';
-import { theme } from '../theme';
+import React, { useEffect } from "react";
+import { addons } from "@storybook/preview-api";
+import { DARK_MODE_EVENT_NAME } from "storybook-dark-mode";
+import { MantineProvider, useMantineColorScheme } from "@mantine/core";
+import { theme } from "../theme";
 
 export const parameters = {
-  layout: 'fullscreen',
+  layout: "fullscreen",
   options: {
     showPanel: false,
   },
@@ -17,7 +17,8 @@ const channel = addons.getChannel();
 
 function ColorSchemeWrapper({ children }: { children: React.ReactNode }) {
   const { setColorScheme } = useMantineColorScheme();
-  const handleColorScheme = (value: boolean) => setColorScheme(value ? 'dark' : 'light');
+  const handleColorScheme = (value: boolean) =>
+    setColorScheme(value ? "dark" : "light");
 
   useEffect(() => {
     channel.on(DARK_MODE_EVENT_NAME, handleColorScheme);
@@ -28,6 +29,10 @@ function ColorSchemeWrapper({ children }: { children: React.ReactNode }) {
 }
 
 export const decorators = [
-  (renderStory: any) => <ColorSchemeWrapper>{renderStory()}</ColorSchemeWrapper>,
-  (renderStory: any) => <MantineProvider theme={theme}>{renderStory()}</MantineProvider>,
+  (renderStory: any) => (
+    <ColorSchemeWrapper>{renderStory()}</ColorSchemeWrapper>
+  ),
+  (renderStory: any) => (
+    <MantineProvider theme={theme}>{renderStory()}</MantineProvider>
+  ),
 ];

--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -7,10 +7,10 @@ import { MantineProvider, useMantineColorScheme } from "@mantine/core";
 import { theme } from "../theme";
 
 export const parameters = {
-  nextjs:{
+  nextjs: {
     appDirectory: true,
   },
-  layout: 'fullscreen',
+  layout: "fullscreen",
   options: {
     showPanel: false,
   },

--- a/docker/aspa-devel.dockerfile
+++ b/docker/aspa-devel.dockerfile
@@ -5,12 +5,10 @@ FROM ${BASE_REGISTRY}/${BASE_IMAGE} AS base
 
 USER root
 
-# Install Git and bash
-RUN apk add --no-cache git bash
-
-# Corepack
-RUN corepack enable
-RUN corepack prepare yarn@stable --activate
+# Install git, bash, and corepack
+RUN apk add --no-cache git bash && \
+	corepack enable && \
+	corepack prepare yarn@stable --activate
 
 # Enable terminal for VSCode
 ENV SHELL /bin/bash

--- a/docker/aspa-devel.dockerfile
+++ b/docker/aspa-devel.dockerfile
@@ -11,6 +11,6 @@ RUN apk add --no-cache git bash && \
 	corepack prepare yarn@stable --activate
 
 # Enable terminal for VSCode
-ENV SHELL /bin/bash
+ENV SHELL=/bin/bash
 
 VOLUME [ "/repo" ]


### PR DESCRIPTION
## Context
This PR optimizes our Docker images (both development and runtime) to reduce image sizes and improve build times in our CI/CD pipeline.

<!-- Close the issue this pr is linked to by typing # and the number of your issue, if it exists-->
[Closes#123](https://github.com/UoaWDCC/aspa-portal-v3/issues/123)

## What Changed?
**Development Image**
* Combined RUN commands to reduce the number of layers

**Runtime Image**
* Implemented Multi-staged builds
* Dependencies are put into a separate layer to leverage build caching
* Removed tsconfig from runtime image, removed copying node_modules in favor of installing dependencies on runtime stage.

## How To Review
1. Review `aspa-devel.dockerfile` for development environment dockerfile changes
2. Review `aspa-runtime.dockerfile` for production environment dockerfile changes
3. Check `.dockerignore` if proper file exclusions are set
4. Verify that the docker build process works and final image sizes are reduced

## Testing
1. Built both images
```
docker build -f docker/aspa-devel.dockerfile -t aspa-devel:test .
docker build -f docker/aspa-runtime.dockerfile -t aspa-runtime:test .
```
2. Verify the image sizes and compared with the original image sizes.
```
docker images | grep aspa
```
3. Test both development and runtime images.
```
docker run -it --rm aspa-devel:test
docker run -it --rm -p 3000:3000 aspa-runtime:test
```


## Risks
<!-- Where should the reviewer focus on (if any)? -->
* Need to verify all development tools work in optimized dev image
* `.dockerignore` file might need adjustment


## Notes
* Improved image sizes:
  * Development: 253.36MB
  * Runtime: 1.36GB
* Development image has not been reduced (idk why)
* Runtime image has been reduced to around ~76% of its original size.
* Timings

![image](https://github.com/user-attachments/assets/c6eddd09-9ac8-4c02-b00d-f2d20c5802d0)

![image](https://github.com/user-attachments/assets/b6b868a9-1c07-48cb-8253-2604e0f9ebae)