### PR TITLE
Feature/leaderboard list display

### DIFF
--- a/app/elo/page.tsx
+++ b/app/elo/page.tsx
@@ -3,9 +3,9 @@
 import { LeaderboardListDisplay } from "@/components/Leaderboard/LeaderboardListDisplay";
 import { useEffect, useState } from "react";
 
-// Constants for padding (in px)
-const PAGE_PADDING_TOP = 180; 
-const PAGE_PADDING_BOTTOM = 30;
+// Page padding (in vw)
+const PAGE_PADDING_TOP_VW = 12;
+const PAGE_PADDING_BOTTOM_VW = 2;
 
 interface LeaderboardEntry {
   rank: number;
@@ -34,8 +34,8 @@ export default function LeaderboardPage() {
   return (
     <div
       style={{
-        paddingTop: `${PAGE_PADDING_TOP}px`,
-        paddingBottom: `${PAGE_PADDING_BOTTOM}px`,
+        paddingTop: `${PAGE_PADDING_TOP_VW}vw`,
+        paddingBottom: `${PAGE_PADDING_BOTTOM_VW}vw`,
       }}
     >
       <LeaderboardListDisplay leaderboard={leaderboard} />

--- a/app/elo/page.tsx
+++ b/app/elo/page.tsx
@@ -1,0 +1,36 @@
+"use client";
+
+import { LeaderboardListDisplay } from "@/components/Leaderboard/LeaderboardListDisplay";
+import { useEffect, useState } from "react";
+
+interface LeaderboardEntry {
+  rank: number;
+  name: string;
+  soloWon: number;
+  duoWon: number;
+  points: number;
+}
+
+export default function LeaderboardPage() {
+  const [leaderboard, setLeaderboard] = useState<LeaderboardEntry[]>([]);
+
+  useEffect(() => {
+    // TODO: Replace with API call if needed
+    const sampleData: LeaderboardEntry[] = [
+      { rank: 1, name: "Person 1", soloWon: 14, duoWon: 1, points: 150 },
+      { rank: 2, name: "Person 12", soloWon: 12, duoWon: 2, points: 140 },
+      { rank: 3, name: "Person 51", soloWon: 12, duoWon: 0, points: 120 },
+      { rank: 4, name: "Person 17", soloWon: 10, duoWon: 2, points: 120 },
+      { rank: 5, name: "Person 7", soloWon: 10, duoWon: 1, points: 110 },
+      { rank: 6, name: "Person 20", soloWon: 9, duoWon: 3, points: 100 },
+      { rank: 7, name: "Person 25", soloWon: 8, duoWon: 4, points: 95 },
+    ];
+    setLeaderboard(sampleData);
+  }, []);
+
+  return (
+    <div style={{ paddingTop: "180px", paddingBottom: "30px" }}>
+      <LeaderboardListDisplay leaderboard={leaderboard} />
+    </div>
+  );
+}

--- a/app/elo/page.tsx
+++ b/app/elo/page.tsx
@@ -3,6 +3,10 @@
 import { LeaderboardListDisplay } from "@/components/Leaderboard/LeaderboardListDisplay";
 import { useEffect, useState } from "react";
 
+// Constants for padding (in px)
+const PAGE_PADDING_TOP = 180; 
+const PAGE_PADDING_BOTTOM = 30;
+
 interface LeaderboardEntry {
   rank: number;
   name: string;
@@ -15,7 +19,6 @@ export default function LeaderboardPage() {
   const [leaderboard, setLeaderboard] = useState<LeaderboardEntry[]>([]);
 
   useEffect(() => {
-    // TODO: Replace with API call if needed
     const sampleData: LeaderboardEntry[] = [
       { rank: 1, name: "Person 1", soloWon: 14, duoWon: 1, points: 150 },
       { rank: 2, name: "Person 12", soloWon: 12, duoWon: 2, points: 140 },
@@ -29,7 +32,12 @@ export default function LeaderboardPage() {
   }, []);
 
   return (
-    <div style={{ paddingTop: "180px", paddingBottom: "30px" }}>
+    <div
+      style={{
+        paddingTop: `${PAGE_PADDING_TOP}px`,
+        paddingBottom: `${PAGE_PADDING_BOTTOM}px`,
+      }}
+    >
       <LeaderboardListDisplay leaderboard={leaderboard} />
     </div>
   );

--- a/app/elo/page.tsx
+++ b/app/elo/page.tsx
@@ -3,7 +3,6 @@
 import { LeaderboardListDisplay } from "@/components/Leaderboard/LeaderboardListDisplay";
 import { useEffect, useState } from "react";
 
-// Page padding (in vw)
 const PAGE_PADDING_TOP_VW = 12;
 const PAGE_PADDING_BOTTOM_VW = 2;
 
@@ -17,6 +16,7 @@ interface LeaderboardEntry {
 
 export default function LeaderboardPage() {
   const [leaderboard, setLeaderboard] = useState<LeaderboardEntry[]>([]);
+  const currentUserRank = 7; // Example: logged-in player is rank 7
 
   useEffect(() => {
     const sampleData: LeaderboardEntry[] = [
@@ -26,7 +26,9 @@ export default function LeaderboardPage() {
       { rank: 4, name: "Person 17", soloWon: 10, duoWon: 2, points: 120 },
       { rank: 5, name: "Person 7", soloWon: 10, duoWon: 1, points: 110 },
       { rank: 6, name: "Person 20", soloWon: 9, duoWon: 3, points: 100 },
-      { rank: 7, name: "Person 25", soloWon: 8, duoWon: 4, points: 95 },
+      { rank: 7, name: "You", soloWon: 8, duoWon: 4, points: 95 },
+      { rank: 8, name: "Person 30", soloWon: 7, duoWon: 3, points: 90 },
+      { rank: 9, name: "Person 40", soloWon: 6, duoWon: 2, points: 85 },
     ];
     setLeaderboard(sampleData);
   }, []);
@@ -38,7 +40,10 @@ export default function LeaderboardPage() {
         paddingBottom: `${PAGE_PADDING_BOTTOM_VW}vw`,
       }}
     >
-      <LeaderboardListDisplay leaderboard={leaderboard} />
+      <LeaderboardListDisplay
+        leaderboard={leaderboard}
+        currentUserRank={currentUserRank}
+      />
     </div>
   );
 }

--- a/components/Leaderboard/LeaderboardListDisplay.module.css
+++ b/components/Leaderboard/LeaderboardListDisplay.module.css
@@ -1,6 +1,6 @@
 .container {
   overflow-y: auto;
-  border-radius: 8px;
+  border-radius: 0.6vw;
   font-family: sans-serif;
 }
 
@@ -11,7 +11,6 @@
   color: white;
 }
 
-
 .name {
   flex: 1;
 }
@@ -19,7 +18,7 @@
 .wins {
   font-size: 0.9rem;
   text-align: right;
-  margin-right: 20px;
+  margin-right: 1.5vw;
 }
 
 .points {

--- a/components/Leaderboard/LeaderboardListDisplay.module.css
+++ b/components/Leaderboard/LeaderboardListDisplay.module.css
@@ -1,7 +1,23 @@
 .container {
-  overflow-y: auto;
   border-radius: 0.6vw;
   font-family: sans-serif;
+  display: flex;
+  flex-direction: column;
+}
+
+.stickyRow {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  font-weight: bold;
+  color: white;
+}
+
+.scrollArea {
+  overflow-y: auto;
 }
 
 .row {

--- a/components/Leaderboard/LeaderboardListDisplay.module.css
+++ b/components/Leaderboard/LeaderboardListDisplay.module.css
@@ -1,5 +1,4 @@
 .container {
-  max-height: 400px; /* Fits ~5 rows */
   overflow-y: auto;
   border-radius: 8px;
   font-family: sans-serif;
@@ -9,21 +8,9 @@
   display: flex;
   align-items: center;
   justify-content: space-between;
-  padding: 12px 20px;
   color: white;
 }
 
-.lightRow {
-  background-color: #7a7f87;
-}
-
-.darkRow {
-  background-color: #111111;
-}
-
-.rank {
-  width: 40px;
-}
 
 .name {
   flex: 1;
@@ -37,6 +24,5 @@
 
 .points {
   font-weight: bold;
-  width: 50px;
   text-align: right;
 }

--- a/components/Leaderboard/LeaderboardListDisplay.module.css
+++ b/components/Leaderboard/LeaderboardListDisplay.module.css
@@ -1,0 +1,42 @@
+.container {
+  max-height: 400px; /* Fits ~5 rows */
+  overflow-y: auto;
+  border-radius: 8px;
+  font-family: sans-serif;
+}
+
+.row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 12px 20px;
+  color: white;
+}
+
+.lightRow {
+  background-color: #7a7f87;
+}
+
+.darkRow {
+  background-color: #111111;
+}
+
+.rank {
+  width: 40px;
+}
+
+.name {
+  flex: 1;
+}
+
+.wins {
+  font-size: 0.9rem;
+  text-align: right;
+  margin-right: 20px;
+}
+
+.points {
+  font-weight: bold;
+  width: 50px;
+  text-align: right;
+}

--- a/components/Leaderboard/LeaderboardListDisplay.story.tsx
+++ b/components/Leaderboard/LeaderboardListDisplay.story.tsx
@@ -1,0 +1,44 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { LeaderboardListDisplay } from "./LeaderboardListDisplay";
+
+const meta: Meta<typeof LeaderboardListDisplay> = {
+  title: "Components/LeaderboardListDisplay",
+  component: LeaderboardListDisplay,
+  tags: ["autodocs"],
+};
+
+export default meta;
+type Story = StoryObj<typeof LeaderboardListDisplay>;
+
+const sampleData = [
+  { rank: 1, name: "Person 1", soloWon: 14, duoWon: 1, points: 150 },
+  { rank: 2, name: "Person 12", soloWon: 12, duoWon: 2, points: 140 },
+  { rank: 3, name: "Person 51", soloWon: 12, duoWon: 0, points: 120 },
+  { rank: 4, name: "Person 17", soloWon: 10, duoWon: 2, points: 120 },
+  { rank: 5, name: "Person 7", soloWon: 10, duoWon: 1, points: 110 },
+  { rank: 6, name: "Person 20", soloWon: 9, duoWon: 3, points: 100 },
+  { rank: 7, name: "Person 25", soloWon: 8, duoWon: 4, points: 95 },
+  { rank: 8, name: "Person 30", soloWon: 7, duoWon: 3, points: 90 },
+];
+
+export const Default: Story = {
+  args: {
+    leaderboard: sampleData,
+  },
+};
+
+export const FewEntries: Story = {
+  args: {
+    leaderboard: sampleData.slice(0, 3),
+  },
+};
+
+export const ManyEntries: Story = {
+  args: {
+    leaderboard: [
+      ...sampleData,
+      { rank: 9, name: "Person 35", soloWon: 6, duoWon: 4, points: 85 },
+      { rank: 10, name: "Person 40", soloWon: 5, duoWon: 3, points: 80 },
+    ],
+  },
+};

--- a/components/Leaderboard/LeaderboardListDisplay.test.tsx
+++ b/components/Leaderboard/LeaderboardListDisplay.test.tsx
@@ -15,9 +15,7 @@ const mockLeaderboard = [
 
 describe("LeaderboardListDisplay", () => {
   it("renders all leaderboard entries", () => {
-    render(
-      <LeaderboardListDisplay leaderboard={mockLeaderboard} />
-    );
+    render(<LeaderboardListDisplay leaderboard={mockLeaderboard} />);
 
     mockLeaderboard.forEach((entry) => {
       expect(screen.getByText(entry.name)).toBeInTheDocument();
@@ -30,7 +28,7 @@ describe("LeaderboardListDisplay", () => {
       <LeaderboardListDisplay
         leaderboard={mockLeaderboard}
         currentUserRank={7}
-      />
+      />,
     );
 
     // Sticky row should contain current user info
@@ -50,7 +48,7 @@ describe("LeaderboardListDisplay", () => {
       <LeaderboardListDisplay
         leaderboard={mockLeaderboard}
         currentUserRank={7}
-      />
+      />,
     );
 
     const stickyRowEl = container.querySelector(`.${"stickyRow"}`);
@@ -62,7 +60,7 @@ describe("LeaderboardListDisplay", () => {
 
   it("should allow scrolling when more than 5 entries", () => {
     const { container } = render(
-      <LeaderboardListDisplay leaderboard={mockLeaderboard} />
+      <LeaderboardListDisplay leaderboard={mockLeaderboard} />,
     );
 
     const scrollArea = container.querySelector(`.${"scrollArea"}`);

--- a/components/Leaderboard/LeaderboardListDisplay.test.tsx
+++ b/components/Leaderboard/LeaderboardListDisplay.test.tsx
@@ -1,0 +1,71 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import { LeaderboardListDisplay } from "./LeaderboardListDisplay";
+
+const mockLeaderboard = [
+  { rank: 1, name: "Person 1", soloWon: 14, duoWon: 1, points: 150 },
+  { rank: 2, name: "Person 12", soloWon: 12, duoWon: 2, points: 140 },
+  { rank: 3, name: "Person 51", soloWon: 12, duoWon: 0, points: 120 },
+  { rank: 4, name: "Person 17", soloWon: 10, duoWon: 2, points: 120 },
+  { rank: 5, name: "Person 7", soloWon: 10, duoWon: 1, points: 110 },
+  { rank: 6, name: "Person 20", soloWon: 9, duoWon: 3, points: 100 },
+  { rank: 7, name: "You", soloWon: 8, duoWon: 4, points: 95 },
+  { rank: 8, name: "Person 30", soloWon: 7, duoWon: 3, points: 90 },
+];
+
+describe("LeaderboardListDisplay", () => {
+  it("renders all leaderboard entries", () => {
+    render(
+      <LeaderboardListDisplay leaderboard={mockLeaderboard} />
+    );
+
+    mockLeaderboard.forEach((entry) => {
+      expect(screen.getByText(entry.name)).toBeInTheDocument();
+      expect(screen.getByText(`${entry.points}`)).toBeInTheDocument();
+    });
+  });
+
+  it("renders the sticky row for the current user", () => {
+    render(
+      <LeaderboardListDisplay
+        leaderboard={mockLeaderboard}
+        currentUserRank={7}
+      />
+    );
+
+    // Sticky row should contain current user info
+    const stickyRow = screen.getAllByText("You")[0];
+    expect(stickyRow).toBeInTheDocument();
+
+    // Points in sticky row
+    expect(screen.getAllByText("95")[0]).toBeInTheDocument();
+
+    // Solo/Duo won info in sticky row
+    expect(screen.getAllByText(/Solo won: 8/i)[0]).toBeInTheDocument();
+    expect(screen.getAllByText(/Duo won: 4/i)[0]).toBeInTheDocument();
+  });
+
+  it("highlights the sticky row with a custom background color", () => {
+    const { container } = render(
+      <LeaderboardListDisplay
+        leaderboard={mockLeaderboard}
+        currentUserRank={7}
+      />
+    );
+
+    const stickyRowEl = container.querySelector(`.${"stickyRow"}`);
+    expect(stickyRowEl).toBeTruthy();
+
+    // Inline style should include background-color from constants
+    expect(stickyRowEl?.getAttribute("style")).toMatch(/background-color/i);
+  });
+
+  it("should allow scrolling when more than 5 entries", () => {
+    const { container } = render(
+      <LeaderboardListDisplay leaderboard={mockLeaderboard} />
+    );
+
+    const scrollArea = container.querySelector(`.${"scrollArea"}`);
+    expect(scrollArea).toHaveStyle("overflow-y: auto");
+  });
+});

--- a/components/Leaderboard/LeaderboardListDisplay.tsx
+++ b/components/Leaderboard/LeaderboardListDisplay.tsx
@@ -1,0 +1,55 @@
+"use client";
+
+import React from "react";
+import styles from "./LeaderboardListDisplay.module.css";
+
+interface LeaderboardEntry {
+  rank: number;
+  name: string;
+  soloWon: number;
+  duoWon: number;
+  points: number;
+}
+
+interface LeaderboardListDisplayProps {
+  leaderboard: LeaderboardEntry[];
+}
+
+export const LeaderboardListDisplay: React.FC<LeaderboardListDisplayProps> = ({ leaderboard }) => {
+  return (
+    <div className={styles.container}>
+      {leaderboard.map((entry) => (
+        <div
+          key={entry.rank}
+          className={`${styles.row} ${entry.rank % 2 === 0 ? styles.darkRow : styles.lightRow}`}
+        >
+          <div className={styles.rank}>{entry.rank}.</div>
+
+          <div className={styles.name}>{entry.name}</div>
+
+          <div className={styles.wins}>
+            <div>Solo won: {entry.soloWon}</div>
+            <div>Duo won: {entry.duoWon}</div>
+          </div>
+
+          <div className={styles.points}>{entry.points}</div>
+        </div>
+      ))}
+    </div>
+  );
+};
+
+// Example usage
+const sampleData: LeaderboardEntry[] = [
+  { rank: 1, name: "Person 1", soloWon: 14, duoWon: 1, points: 150 },
+  { rank: 2, name: "Person 12", soloWon: 12, duoWon: 2, points: 140 },
+  { rank: 3, name: "Person 51", soloWon: 12, duoWon: 0, points: 120 },
+  { rank: 4, name: "Person 17", soloWon: 10, duoWon: 2, points: 120 },
+  { rank: 5, name: "Person 7", soloWon: 10, duoWon: 1, points: 110 },
+  { rank: 6, name: "Person 20", soloWon: 9, duoWon: 3, points: 100 },
+  { rank: 7, name: "Person 25", soloWon: 8, duoWon: 4, points: 95 },
+];
+
+export default function LeaderboardPage() {
+  return <LeaderboardListDisplay leaderboard={sampleData} />;
+}

--- a/components/Leaderboard/LeaderboardListDisplay.tsx
+++ b/components/Leaderboard/LeaderboardListDisplay.tsx
@@ -30,7 +30,7 @@ interface LeaderboardEntry {
 interface LeaderboardListDisplayProps {
   leaderboard: LeaderboardEntry[];
   // prop for highlighting & user sticky row
-  currentUserRank?: number; 
+  currentUserRank?: number;
 }
 
 export const LeaderboardListDisplay: React.FC<LeaderboardListDisplayProps> = ({
@@ -38,7 +38,7 @@ export const LeaderboardListDisplay: React.FC<LeaderboardListDisplayProps> = ({
   currentUserRank,
 }) => {
   const currentUserEntry = leaderboard.find(
-    (entry) => entry.rank === currentUserRank
+    (entry) => entry.rank === currentUserRank,
   );
 
   return (
@@ -82,7 +82,10 @@ export const LeaderboardListDisplay: React.FC<LeaderboardListDisplayProps> = ({
               padding: `${PADDING_Y_VW}vw ${PADDING_X_VW}vw`,
             }}
           >
-            <div className={styles.rank} style={{ width: `${RANK_WIDTH_VW}vw` }}>
+            <div
+              className={styles.rank}
+              style={{ width: `${RANK_WIDTH_VW}vw` }}
+            >
               {entry.rank}.
             </div>
             <div className={styles.name}>{entry.name}</div>

--- a/components/Leaderboard/LeaderboardListDisplay.tsx
+++ b/components/Leaderboard/LeaderboardListDisplay.tsx
@@ -4,12 +4,14 @@ import React from "react";
 import styles from "./LeaderboardListDisplay.module.css";
 
 // Constants for styling
-export const ROW_HEIGHT_VW = 5; 
-export const VISIBLE_ROWS = 5; 
-export const MAX_HEIGHT_VW = ROW_HEIGHT_VW * VISIBLE_ROWS; 
+export const ROW_HEIGHT_VW = 5;
+export const VISIBLE_ROWS = 5;
+export const MAX_HEIGHT_VW = ROW_HEIGHT_VW * VISIBLE_ROWS;
 
 export const LIGHT_ROW_COLOR = "#7a7f87";
 export const DARK_ROW_COLOR = "#111111";
+// highlighting specific user's row
+export const HIGHLIGHT_COLOR = "#DD995B";
 
 export const RANK_WIDTH_VW = 3;
 export const POINTS_WIDTH_VW = 4;
@@ -26,39 +28,75 @@ interface LeaderboardEntry {
 
 interface LeaderboardListDisplayProps {
   leaderboard: LeaderboardEntry[];
+  currentUserRank?: number; // new prop for highlighting & sticky
 }
 
-export const LeaderboardListDisplay: React.FC<LeaderboardListDisplayProps> = ({ leaderboard }) => {
+export const LeaderboardListDisplay: React.FC<LeaderboardListDisplayProps> = ({
+  leaderboard,
+  currentUserRank,
+}) => {
+  const currentUserEntry = leaderboard.find(
+    (entry) => entry.rank === currentUserRank
+  );
+
   return (
     <div
       className={styles.container}
       style={{ maxHeight: `${MAX_HEIGHT_VW}vw` }}
     >
-      {leaderboard.map((entry) => (
+      {currentUserEntry && (
         <div
-          key={entry.rank}
-          className={styles.row}
+          className={styles.stickyRow}
           style={{
-            backgroundColor: entry.rank % 2 === 0 ? DARK_ROW_COLOR : LIGHT_ROW_COLOR,
+            backgroundColor: HIGHLIGHT_COLOR,
             padding: `${PADDING_Y_VW}vw ${PADDING_X_VW}vw`,
           }}
         >
           <div className={styles.rank} style={{ width: `${RANK_WIDTH_VW}vw` }}>
-            {entry.rank}.
+            {currentUserEntry.rank}.
           </div>
-
-          <div className={styles.name}>{entry.name}</div>
-
+          <div className={styles.name}>{currentUserEntry.name}</div>
           <div className={styles.wins}>
-            <div>Solo won: {entry.soloWon}</div>
-            <div>Duo won: {entry.duoWon}</div>
+            <div>Solo won: {currentUserEntry.soloWon}</div>
+            <div>Duo won: {currentUserEntry.duoWon}</div>
           </div>
-
-          <div className={styles.points} style={{ width: `${POINTS_WIDTH_VW}vw` }}>
-            {entry.points}
+          <div
+            className={styles.points}
+            style={{ width: `${POINTS_WIDTH_VW}vw` }}
+          >
+            {currentUserEntry.points}
           </div>
         </div>
-      ))}
+      )}
+
+      <div className={styles.scrollArea}>
+        {leaderboard.map((entry) => (
+          <div
+            key={entry.rank}
+            className={styles.row}
+            style={{
+              backgroundColor:
+                entry.rank % 2 === 0 ? DARK_ROW_COLOR : LIGHT_ROW_COLOR,
+              padding: `${PADDING_Y_VW}vw ${PADDING_X_VW}vw`,
+            }}
+          >
+            <div className={styles.rank} style={{ width: `${RANK_WIDTH_VW}vw` }}>
+              {entry.rank}.
+            </div>
+            <div className={styles.name}>{entry.name}</div>
+            <div className={styles.wins}>
+              <div>Solo won: {entry.soloWon}</div>
+              <div>Duo won: {entry.duoWon}</div>
+            </div>
+            <div
+              className={styles.points}
+              style={{ width: `${POINTS_WIDTH_VW}vw` }}
+            >
+              {entry.points}
+            </div>
+          </div>
+        ))}
+      </div>
     </div>
   );
 };

--- a/components/Leaderboard/LeaderboardListDisplay.tsx
+++ b/components/Leaderboard/LeaderboardListDisplay.tsx
@@ -3,6 +3,19 @@
 import React from "react";
 import styles from "./LeaderboardListDisplay.module.css";
 
+// Styling constants
+export const ROW_HEIGHT = 80; 
+export const VISIBLE_ROWS = 5; 
+export const MAX_HEIGHT = ROW_HEIGHT * VISIBLE_ROWS; 
+
+export const LIGHT_ROW_COLOR = "#7a7f87";
+export const DARK_ROW_COLOR = "#111111";
+
+export const RANK_WIDTH = 40;
+export const POINTS_WIDTH = 50;
+export const PADDING_X = 20;
+export const PADDING_Y = 12;
+
 interface LeaderboardEntry {
   rank: number;
   name: string;
@@ -17,13 +30,22 @@ interface LeaderboardListDisplayProps {
 
 export const LeaderboardListDisplay: React.FC<LeaderboardListDisplayProps> = ({ leaderboard }) => {
   return (
-    <div className={styles.container}>
+    <div
+      className={styles.container}
+      style={{ maxHeight: `${MAX_HEIGHT}px` }} // Uses constant
+    >
       {leaderboard.map((entry) => (
         <div
           key={entry.rank}
-          className={`${styles.row} ${entry.rank % 2 === 0 ? styles.darkRow : styles.lightRow}`}
+          className={styles.row}
+          style={{
+            backgroundColor: entry.rank % 2 === 0 ? DARK_ROW_COLOR : LIGHT_ROW_COLOR,
+            padding: `${PADDING_Y}px ${PADDING_X}px`,
+          }}
         >
-          <div className={styles.rank}>{entry.rank}.</div>
+          <div className={styles.rank} style={{ width: `${RANK_WIDTH}px` }}>
+            {entry.rank}.
+          </div>
 
           <div className={styles.name}>{entry.name}</div>
 
@@ -32,24 +54,11 @@ export const LeaderboardListDisplay: React.FC<LeaderboardListDisplayProps> = ({ 
             <div>Duo won: {entry.duoWon}</div>
           </div>
 
-          <div className={styles.points}>{entry.points}</div>
+          <div className={styles.points} style={{ width: `${POINTS_WIDTH}px` }}>
+            {entry.points}
+          </div>
         </div>
       ))}
     </div>
   );
 };
-
-// Example usage
-const sampleData: LeaderboardEntry[] = [
-  { rank: 1, name: "Person 1", soloWon: 14, duoWon: 1, points: 150 },
-  { rank: 2, name: "Person 12", soloWon: 12, duoWon: 2, points: 140 },
-  { rank: 3, name: "Person 51", soloWon: 12, duoWon: 0, points: 120 },
-  { rank: 4, name: "Person 17", soloWon: 10, duoWon: 2, points: 120 },
-  { rank: 5, name: "Person 7", soloWon: 10, duoWon: 1, points: 110 },
-  { rank: 6, name: "Person 20", soloWon: 9, duoWon: 3, points: 100 },
-  { rank: 7, name: "Person 25", soloWon: 8, duoWon: 4, points: 95 },
-];
-
-export default function LeaderboardPage() {
-  return <LeaderboardListDisplay leaderboard={sampleData} />;
-}

--- a/components/Leaderboard/LeaderboardListDisplay.tsx
+++ b/components/Leaderboard/LeaderboardListDisplay.tsx
@@ -10,6 +10,7 @@ export const MAX_HEIGHT_VW = ROW_HEIGHT_VW * VISIBLE_ROWS;
 
 export const LIGHT_ROW_COLOR = "#7a7f87";
 export const DARK_ROW_COLOR = "#111111";
+
 // highlighting specific user's row
 export const HIGHLIGHT_COLOR = "#DD995B";
 
@@ -28,7 +29,8 @@ interface LeaderboardEntry {
 
 interface LeaderboardListDisplayProps {
   leaderboard: LeaderboardEntry[];
-  currentUserRank?: number; // new prop for highlighting & sticky
+  // prop for highlighting & user sticky row
+  currentUserRank?: number; 
 }
 
 export const LeaderboardListDisplay: React.FC<LeaderboardListDisplayProps> = ({

--- a/components/Leaderboard/LeaderboardListDisplay.tsx
+++ b/components/Leaderboard/LeaderboardListDisplay.tsx
@@ -3,18 +3,18 @@
 import React from "react";
 import styles from "./LeaderboardListDisplay.module.css";
 
-// Styling constants
-export const ROW_HEIGHT = 80; 
+// Constants for styling
+export const ROW_HEIGHT_VW = 5; 
 export const VISIBLE_ROWS = 5; 
-export const MAX_HEIGHT = ROW_HEIGHT * VISIBLE_ROWS; 
+export const MAX_HEIGHT_VW = ROW_HEIGHT_VW * VISIBLE_ROWS; 
 
 export const LIGHT_ROW_COLOR = "#7a7f87";
 export const DARK_ROW_COLOR = "#111111";
 
-export const RANK_WIDTH = 40;
-export const POINTS_WIDTH = 50;
-export const PADDING_X = 20;
-export const PADDING_Y = 12;
+export const RANK_WIDTH_VW = 3;
+export const POINTS_WIDTH_VW = 4;
+export const PADDING_X_VW = 2;
+export const PADDING_Y_VW = 1;
 
 interface LeaderboardEntry {
   rank: number;
@@ -32,7 +32,7 @@ export const LeaderboardListDisplay: React.FC<LeaderboardListDisplayProps> = ({ 
   return (
     <div
       className={styles.container}
-      style={{ maxHeight: `${MAX_HEIGHT}px` }} // Uses constant
+      style={{ maxHeight: `${MAX_HEIGHT_VW}vw` }}
     >
       {leaderboard.map((entry) => (
         <div
@@ -40,10 +40,10 @@ export const LeaderboardListDisplay: React.FC<LeaderboardListDisplayProps> = ({ 
           className={styles.row}
           style={{
             backgroundColor: entry.rank % 2 === 0 ? DARK_ROW_COLOR : LIGHT_ROW_COLOR,
-            padding: `${PADDING_Y}px ${PADDING_X}px`,
+            padding: `${PADDING_Y_VW}vw ${PADDING_X_VW}vw`,
           }}
         >
-          <div className={styles.rank} style={{ width: `${RANK_WIDTH}px` }}>
+          <div className={styles.rank} style={{ width: `${RANK_WIDTH_VW}vw` }}>
             {entry.rank}.
           </div>
 
@@ -54,7 +54,7 @@ export const LeaderboardListDisplay: React.FC<LeaderboardListDisplayProps> = ({ 
             <div>Duo won: {entry.duoWon}</div>
           </div>
 
-          <div className={styles.points} style={{ width: `${POINTS_WIDTH}px` }}>
+          <div className={styles.points} style={{ width: `${POINTS_WIDTH_VW}vw` }}>
             {entry.points}
           </div>
         </div>


### PR DESCRIPTION
Summary:
- Implemented the Leaderboard list based on the Figma design.
- Added a sticky row for the current user’s rank so it can be easily accessed later.
- Applied an orange highlight to the user’s rank row to make it more eye-catching. This highlight is an individual application for now and can be removed if needed.

Notes:
- Sticky row implementation may require refinement depending on future design or interaction requirements.
- The highlight is optional and currently intended for visibility/testing.